### PR TITLE
Compatible with td-agent 2

### DIFF
--- a/.ebextensions/1-td-agent-install.config
+++ b/.ebextensions/1-td-agent-install.config
@@ -1,14 +1,10 @@
 # errors get logged to /var/log/cfn-init.log. See Also /var/log/eb-tools.log
 commands:
     01-command:
-        command: wget -O/etc/yum.repos.d/treasure-data.repo https://raw.github.com/treasure-data/td-agent/master/redhat/treasure-data.repo
+        command: echo 'Defaults:root    !requiretty' >> /etc/sudoers
 
     02-command:
-        command: yum check-update
-        ignoreErrors: true
+        command: curl -L http://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.sh | sh
 
     03-command:
-        command: yum install -y --nogpgcheck td-agent
-
-    04-command:
         command: /etc/init.d/td-agent restart

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Please modify your configuration if you want.
     
 Finally, please deploy the change into the production.
 
+    $ eb init
     $ git add .ebextensions/0-td-agent-gen-config.config
     $ git add .ebextensions/1-td-agent-install.config
     $ git commit -a -m 'custom extensions to install td-agent'
-    $ git aws.push
+    $ eb create
     
 ### How it Works
 


### PR DESCRIPTION
- td-agent2のAmazon Linux対応に合わせ、td-agent1からtd-agent2への変更としてインストールスクリプトの更新
- READMEをElastic Beanstalkの新CLIに対応